### PR TITLE
[feat] : 카카오 로그인 시 회원가입, 토큰에서 유저정보 가져오기

### DIFF
--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/OAuthController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/OAuthController.java
@@ -3,6 +3,7 @@ package com.yapp.lonessum.domain.user.controller;
 import com.yapp.lonessum.domain.user.client.KakaoAuthClient;
 import com.yapp.lonessum.domain.user.dto.KakaoTokenRequest;
 import com.yapp.lonessum.domain.user.dto.KakaoTokenResponse;
+import com.yapp.lonessum.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,11 +16,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/oauth")
 public class OAuthController {
     private final KakaoAuthClient kakaoAuthClient;
+    private final UserService userService;
 
     @GetMapping("/kakao")
     public ResponseEntity<KakaoTokenResponse> getKakaoAuthorization(@RequestParam String code) {
         KakaoTokenRequest kakaoTokenRequest = makeTokenRequest(code);
         KakaoTokenResponse token = kakaoAuthClient.getToken(kakaoTokenRequest);
+        userService.login(token);
 
         return ResponseEntity.ok(token);
     }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/entity/UserEntity.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/entity/UserEntity.java
@@ -21,7 +21,7 @@ public class UserEntity {
     @Id @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    private String kakaoEmail;
+    private Long kakaoServerId;
 
     private String universityEmail;
 

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/repository/UserRepository.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/repository/UserRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
-    Optional<UserEntity> findByKaKaoServerId(Long kakaoServerId);
+    Optional<UserEntity> findByKakaoServerId(Long kakaoServerId);
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/repository/UserRepository.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/repository/UserRepository.java
@@ -3,5 +3,8 @@ package com.yapp.lonessum.domain.user.repository;
 import com.yapp.lonessum.domain.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findByKaKaoServerId(Long kakaoServerId);
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
@@ -1,6 +1,9 @@
 package com.yapp.lonessum.domain.user.service;
 
+import com.yapp.lonessum.domain.user.client.KakaoApiClient;
 import com.yapp.lonessum.domain.user.dto.AuthCodeResponse;
+import com.yapp.lonessum.domain.user.dto.KakaoTokenInfoResponse;
+import com.yapp.lonessum.domain.user.dto.KakaoTokenResponse;
 import com.yapp.lonessum.domain.user.entity.EmailTokenEntity;
 import com.yapp.lonessum.domain.user.entity.UserEntity;
 import com.yapp.lonessum.domain.user.repository.UserRepository;
@@ -9,12 +12,26 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
+    private final KakaoApiClient kakaoApiClient;
     private final UserRepository userRepository;
+
+    @Transactional
+    public void login(KakaoTokenResponse token) {
+        KakaoTokenInfoResponse tokenInfo = kakaoApiClient.getTokenInfo(token.getAccess_token());
+        long kakaoServerId = tokenInfo.getId();
+        Optional<UserEntity> user = userRepository.findByKaKaoServerId(kakaoServerId);
+        if (user.isEmpty()) {
+            userRepository.save(UserEntity.builder()
+                    .kakaoServerId(kakaoServerId)
+                    .build());
+        }
+    }
 
     public void updateUniversityEmail(Long userId, String email) {
 //        UserEntity user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("존재하지 않는 유저입니다."));
@@ -22,7 +39,7 @@ public class UserService {
 
         //테스트용
         UserEntity user = UserEntity.builder()
-                .kakaoEmail("hi@kakao.com")
+                .kakaoServerId(123L)
                 .isAuthenticated(false)
                 .build();
         user.registerUniversityEmail(email);

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
@@ -25,7 +25,7 @@ public class UserService {
     public void login(KakaoTokenResponse token) {
         KakaoTokenInfoResponse tokenInfo = kakaoApiClient.getTokenInfo(token.getAccess_token());
         long kakaoServerId = tokenInfo.getId();
-        Optional<UserEntity> user = userRepository.findByKaKaoServerId(kakaoServerId);
+        Optional<UserEntity> user = userRepository.findByKakaoServerId(kakaoServerId);
         if (user.isEmpty()) {
             userRepository.save(UserEntity.builder()
                     .kakaoServerId(kakaoServerId)

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
@@ -9,8 +9,8 @@ import com.yapp.lonessum.domain.user.entity.UserEntity;
 import com.yapp.lonessum.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -31,6 +31,13 @@ public class UserService {
                     .kakaoServerId(kakaoServerId)
                     .build());
         }
+    }
+
+    @Transactional(readOnly = true)
+    public UserEntity getUserFromToken(String token) {
+        KakaoTokenInfoResponse tokenInfo = kakaoApiClient.getTokenInfo(token);
+        long kakaoServerId = tokenInfo.getId();
+        return userRepository.findByKakaoServerId(kakaoServerId).get();
     }
 
     public void updateUniversityEmail(Long userId, String email) {


### PR DESCRIPTION
- 카카오 로그인 시 발급받는 카카오id를 이용해서 유저DB를 조회
- 유저DB에 존재하지 않는 유저라면 회원가입 진행

- 토큰에서 유저정보를 가져오는 함수 생성

close #34
close #35 