### PR TITLE
유저 정보 가져오기 구현완료

### DIFF
--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/client/KakaoApiClient.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/client/KakaoApiClient.java
@@ -1,6 +1,7 @@
 package com.yapp.lonessum.domain.user.client;
 
 import com.yapp.lonessum.domain.user.dto.KakaoTokenInfoResponse;
+import com.yapp.lonessum.domain.user.dto.KakaoUserResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -13,4 +14,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface KakaoApiClient {
     @GetMapping("/v1/user/access_token_info")
     KakaoTokenInfoResponse getTokenInfo(@RequestHeader("Authorization") String bearerToken);
+
+    @GetMapping("/v2/user/me")
+    KakaoUserResponse getUserInfo(@RequestHeader("Authorization") String bearerToken);
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/OAuthController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/OAuthController.java
@@ -1,8 +1,10 @@
 package com.yapp.lonessum.domain.user.controller;
 
+import com.yapp.lonessum.domain.user.client.KakaoApiClient;
 import com.yapp.lonessum.domain.user.client.KakaoAuthClient;
 import com.yapp.lonessum.domain.user.dto.KakaoTokenRequest;
 import com.yapp.lonessum.domain.user.dto.KakaoTokenResponse;
+import com.yapp.lonessum.domain.user.dto.KakaoUserResponse;
 import com.yapp.lonessum.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,24 +18,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/oauth")
 public class OAuthController {
     private final KakaoAuthClient kakaoAuthClient;
+    private final KakaoApiClient kakaoApiClient;
     private final UserService userService;
 
     @GetMapping("/kakao")
     public ResponseEntity<KakaoTokenResponse> getKakaoAuthorization(@RequestParam String code) {
         KakaoTokenRequest kakaoTokenRequest = makeTokenRequest(code);
         KakaoTokenResponse token = kakaoAuthClient.getToken(kakaoTokenRequest);
+
         userService.login(token);
 
         return ResponseEntity.ok(token);
     }
 
+    //TODO : secret은 배포 전 파일로부터 읽어오게 수정. 그전까지는 테스트할 때만 잠깐 넣고 push 전 제거
     private KakaoTokenRequest makeTokenRequest(String code) {
         return KakaoTokenRequest.builder()
                 .grant_type("authorization_code")
                 .client_id("24608dc716988209e4f923e0a8f4c495")
                 .redirect_uri("http://localhost:8080/oauth/kakao")
                 .code(code)
-                .client_secret("secret")
+                .client_secret("{secret}")
                 .build();
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/KakaoAccount.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/KakaoAccount.java
@@ -1,0 +1,9 @@
+package com.yapp.lonessum.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class KakaoAccount {
+    private Boolean age_range_needs_agreement;
+    private String age_range;
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/KakaoUserResponse.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/KakaoUserResponse.java
@@ -1,0 +1,9 @@
+package com.yapp.lonessum.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class KakaoUserResponse {
+    private Long id;
+    private KakaoAccount kakao_account;
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
@@ -28,7 +28,7 @@ public class UserService {
 
     @Transactional
     public void login(KakaoTokenResponse token) {
-        KakaoTokenInfoResponse tokenInfo = kakaoApiClient.getTokenInfo(token.getAccess_token());
+        KakaoTokenInfoResponse tokenInfo = kakaoApiClient.getTokenInfo("Bearer " + token.getAccess_token());
         long kakaoServerId = tokenInfo.getId();
         Optional<UserEntity> user = userRepository.findByKakaoServerId(kakaoServerId);
         if (user.isEmpty()) {


### PR DESCRIPTION
### 구현사항
- 유저정보(나이) 가져오기 완료
- Authorization header value 잘못된 부분 수정

### 이슈 업 해야할 부분 참고
- 유저의 나이정보를 가져올 때 해당 부분이 동의를 하지 않았을 경우
```
KakaoUserResponse(id=2262328726, kakao_account=KakaoAccount(age_range_needs_agreement=true, age_range=null))
```
이렇게 value는 null이고 age_range_needs_agreement는 true가 나옵니다.
- 위의 정보를 바탕으로 최종 매칭 전 검사를 하여 age_range_needs_agreement가 true일 경우 front 쪽에서 아래 url로 요청을 보내어주면 됩니다.
https://kauth.kakao.com/oauth/authorize?client_id={client_id}&redirect_uri={redirect_url}&response_type=code&range=age_range
- 예시
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/31160622/175817944-2a00c6d5-10d9-4ae2-894b-1448b3d7822f.png">
