### PR TITLE
[feat] : OAuth로 유저 나이정보 받아오기, 설문 작성 시 나이 검사

### DIFF
--- a/lonessum/src/main/java/com/yapp/lonessum/domain/dating/service/DatingSurveyService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/dating/service/DatingSurveyService.java
@@ -29,6 +29,10 @@ public class DatingSurveyService {
             throw new RestApiException(UserErrorCode.NEED_EMAIL_AUTH);
         }
 
+        if (user.getIsAdult() == null || user.getIsAdult() == false) {
+            throw new RestApiException(UserErrorCode.AGE_TOO_YOUNG);
+        }
+
         Optional<DatingSurveyEntity> datingSurvey = datingSurveyRepository.findByUser(user);
         // 설문을 작성한 적 있으면 -> 기존 설문 수정
         if (datingSurvey.isPresent()) {

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/service/MeetingSurveyService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/service/MeetingSurveyService.java
@@ -29,6 +29,10 @@ public class MeetingSurveyService {
             throw new RestApiException(UserErrorCode.NEED_EMAIL_AUTH);
         }
 
+        if (user.getIsAdult() == null || user.getIsAdult() == false) {
+            throw new RestApiException(UserErrorCode.AGE_TOO_YOUNG);
+        }
+
         Optional<MeetingSurveyEntity> meetingSurvey = meetingSurveyRepository.findByUser(user);
         // 설문을 작성한 적 있으면 -> 기존 설문 수정
         if (meetingSurvey.isPresent()) {

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/OAuthController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/OAuthController.java
@@ -46,6 +46,9 @@ public class OAuthController {
     public ResponseEntity getUserAgeFromKakao(@RequestHeader(value = "Authorization") String token) {
         KakaoUserResponse userInfo = kakaoApiClient.getUserInfo("Bearer " + token);
         String age_range = userInfo.getKakao_account().getAge_range();
+        if (age_range == null) {
+            throw new RestApiException(UserErrorCode.NEED_AGE_AGREE);
+        }
         String[] age = age_range.split("~");
         if (Integer.parseInt(age[0]) < 20) {
             userService.checkAdult(token, false);

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/OAuthController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/OAuthController.java
@@ -6,12 +6,11 @@ import com.yapp.lonessum.domain.user.dto.KakaoTokenRequest;
 import com.yapp.lonessum.domain.user.dto.KakaoTokenResponse;
 import com.yapp.lonessum.domain.user.dto.KakaoUserResponse;
 import com.yapp.lonessum.domain.user.service.UserService;
+import com.yapp.lonessum.exception.errorcode.UserErrorCode;
+import com.yapp.lonessum.exception.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,8 +36,22 @@ public class OAuthController {
                 .grant_type("authorization_code")
                 .client_id("24608dc716988209e4f923e0a8f4c495")
                 .redirect_uri("http://localhost:8080/oauth/kakao")
+//                .redirect_uri("http://localhost:3000/oauth/kakao")
                 .code(code)
                 .client_secret("{secret}")
                 .build();
+    }
+
+    @GetMapping("/kakao/age")
+    public ResponseEntity getUserAgeFromKakao(@RequestHeader(value = "Authorization") String token) {
+        KakaoUserResponse userInfo = kakaoApiClient.getUserInfo("Bearer " + token);
+        String age_range = userInfo.getKakao_account().getAge_range();
+        String[] age = age_range.split("~");
+        if (Integer.parseInt(age[0]) < 20) {
+            userService.checkAdult(token, false);
+            throw new RestApiException(UserErrorCode.AGE_TOO_YOUNG);
+        }
+        userService.checkAdult(token, true);
+        return ResponseEntity.ok().build();
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/entity/UserEntity.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/entity/UserEntity.java
@@ -33,6 +33,8 @@ public class UserEntity {
 
     private Boolean isAuthenticated;
 
+    private Boolean isAdult;
+
     @OneToOne(fetch = FetchType.LAZY)
     private MeetingSurveyEntity meetingSurvey;
 
@@ -50,6 +52,10 @@ public class UserEntity {
 
     public void issueEmailToken(EmailTokenEntity emailToken) {
         this.emailToken = emailToken;
+    }
+
+    public void changeIsAdult(Boolean isAdult) {
+        this.isAdult = isAdult;
     }
 
     public void changeMeetingSurvey(MeetingSurveyEntity meetingSurvey) {

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.yapp.lonessum.domain.user.service;
 import com.yapp.lonessum.domain.user.client.KakaoApiClient;
 import com.yapp.lonessum.domain.user.dto.KakaoTokenInfoResponse;
 import com.yapp.lonessum.domain.user.dto.KakaoTokenResponse;
+import com.yapp.lonessum.domain.user.dto.KakaoUserResponse;
 import com.yapp.lonessum.domain.user.entity.UserEntity;
 import com.yapp.lonessum.domain.user.repository.UserRepository;
 import com.yapp.lonessum.exception.errorcode.UserErrorCode;
@@ -38,5 +39,11 @@ public class UserService {
         KakaoTokenInfoResponse tokenInfo = kakaoApiClient.getTokenInfo("Bearer " + token);
         long kakaoServerId = tokenInfo.getId();
         return userRepository.findByKakaoServerId(kakaoServerId).get();
+    }
+
+    @Transactional
+    public void checkAdult(String token, Boolean isAdult) {
+        UserEntity user = getUserFromToken(token);
+        user.changeIsAdult(isAdult);
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/exception/errorcode/UserErrorCode.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/exception/errorcode/UserErrorCode.java
@@ -14,6 +14,8 @@ public enum UserErrorCode implements ErrorCode {
     UNSUPPORTED_EMAIL(HttpStatus.BAD_REQUEST, "지원하지 않는 대학입니다."),
     EXPIRED_AUTHCODE(HttpStatus.BAD_REQUEST, "인증코드의 유효기간이 만료되었습니다. 이메일 전송을 다시 요청해주세요."),
     INVALID_AUTHCODE(HttpStatus.BAD_REQUEST, "인증코드가 일치하지 않습니다. 인증코드를 다시 입력해주세요."),
+    NEED_AGE_AGREE(HttpStatus.BAD_REQUEST, "유저의 나이 정보 제공 동의가 필요합니다."),
+    AGE_TOO_YOUNG(HttpStatus.BAD_REQUEST, "만 19세 이상의 유저만 사용 가능한 서비스 입니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
### OAuth로 정보 받아오는 과정
- 클라이언트가 redirect_url을 프론트 서버로 설정한 뒤 나이 정보 제공 동의 요청
- 리다이렉트 후 인증코드와 함께 /kakao/age로 API를 호출하면 유저의 나이 정보가 업데이트 됨
close #39 