### PR TITLE
[feat] : 페이플 결제 테스트 API

### DIFF
--- a/lonessum/src/main/java/com/yapp/lonessum/domain/dating/entity/DatingMatchingEntity.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/dating/entity/DatingMatchingEntity.java
@@ -22,9 +22,5 @@ public class DatingMatchingEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private DatingMatchingEntity surveyB;
 
-    private Boolean isPaidA;
-
-    private Boolean isPaidB;
-
     private LocalDateTime matchedAt;
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/dating/entity/DatingSurveyEntity.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/dating/entity/DatingSurveyEntity.java
@@ -1,6 +1,7 @@
 package com.yapp.lonessum.domain.dating.entity;
 
 import com.yapp.lonessum.domain.constant.*;
+import com.yapp.lonessum.domain.payment.entity.Payment;
 import com.yapp.lonessum.domain.user.entity.UserEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -108,6 +109,9 @@ public class DatingSurveyEntity {
 
     @Enumerated(EnumType.STRING)
     private MatchStatus matchStatus;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Payment payment;
 
     private Boolean isRandom;
 

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/dating/entity/DatingSurveyEntity.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/dating/entity/DatingSurveyEntity.java
@@ -24,7 +24,7 @@ public class DatingSurveyEntity {
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "datingSurvey")
     private UserEntity user;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "datingSurvey")
     private DatingMatchingEntity datingMatching;
 
     @Enumerated(EnumType.STRING)

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/dating/entity/DatingSurveyEntity.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/dating/entity/DatingSurveyEntity.java
@@ -24,7 +24,7 @@ public class DatingSurveyEntity {
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "datingSurvey")
     private UserEntity user;
 
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "datingSurvey")
+    @OneToOne(fetch = FetchType.LAZY)
     private DatingMatchingEntity datingMatching;
 
     @Enumerated(EnumType.STRING)

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/controller/MeetingMatchingController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/controller/MeetingMatchingController.java
@@ -1,0 +1,26 @@
+package com.yapp.lonessum.domain.meeting.controller;
+
+import com.yapp.lonessum.domain.meeting.service.MeetingMatchingService;
+import com.yapp.lonessum.domain.user.entity.UserEntity;
+import com.yapp.lonessum.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/meeting/matching")
+public class MeetingMatchingController {
+
+    private final UserService userService;
+    private final MeetingMatchingService meetingmatchingService;
+
+    @GetMapping
+    public ResponseEntity getMatchResult(@RequestHeader(value = "Authorization") String token) {
+        UserEntity user = userService.getUserFromToken(token);
+        return ResponseEntity.ok(meetingmatchingService.getMatchResult(user));
+    }
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/entity/MeetingMatchingEntity.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/entity/MeetingMatchingEntity.java
@@ -2,11 +2,13 @@ package com.yapp.lonessum.domain.meeting.entity;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/entity/MeetingMatchingEntity.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/entity/MeetingMatchingEntity.java
@@ -24,9 +24,5 @@ public class MeetingMatchingEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private MeetingSurveyEntity surveyB;
 
-    private Boolean isPaidA;
-
-    private Boolean isPaidB;
-
     private LocalDateTime matchedAt;
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/entity/MeetingSurveyEntity.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/entity/MeetingSurveyEntity.java
@@ -21,7 +21,7 @@ public class MeetingSurveyEntity {
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "meetingSurvey")
     private UserEntity user;
 
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "meetingSurvey")
+    @OneToOne(fetch = FetchType.LAZY)
     private MeetingMatchingEntity meetingMatching;
 
     @Enumerated(EnumType.STRING)

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/entity/MeetingSurveyEntity.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/entity/MeetingSurveyEntity.java
@@ -21,6 +21,9 @@ public class MeetingSurveyEntity {
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "meetingSurvey")
     private UserEntity user;
 
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "meetingSurvey")
+    private MeetingMatchingEntity meetingMatching;
+
     @Enumerated(EnumType.STRING)
     private TypeOfMeeting typeOfMeeting;
 

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/entity/MeetingSurveyEntity.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/entity/MeetingSurveyEntity.java
@@ -1,6 +1,7 @@
 package com.yapp.lonessum.domain.meeting.entity;
 
 import com.yapp.lonessum.domain.constant.*;
+import com.yapp.lonessum.domain.payment.entity.Payment;
 import com.yapp.lonessum.domain.user.entity.UserEntity;
 import lombok.*;
 
@@ -89,6 +90,9 @@ public class MeetingSurveyEntity {
 
     @Enumerated(EnumType.STRING)
     private MatchStatus matchStatus;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Payment payment;
 
     private Boolean isRandom;
 

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/service/MeetingMatchingService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/service/MeetingMatchingService.java
@@ -1,0 +1,47 @@
+package com.yapp.lonessum.domain.meeting.service;
+
+import com.yapp.lonessum.domain.constant.MatchStatus;
+import com.yapp.lonessum.domain.meeting.entity.MeetingSurveyEntity;
+import com.yapp.lonessum.domain.meeting.repository.MeetingMatchingRepository;
+import com.yapp.lonessum.domain.meeting.repository.MeetingSurveyRepository;
+import com.yapp.lonessum.domain.user.entity.UserEntity;
+import com.yapp.lonessum.exception.errorcode.SurveyErrorCode;
+import com.yapp.lonessum.exception.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingMatchingService {
+
+    private final MeetingSurveyRepository meetingSurveyRepository;
+    private final MeetingMatchingRepository meetingMatchingRepository;
+
+    public Object getMatchResult(UserEntity user) {
+        Optional<MeetingSurveyEntity> meetingSurvey = meetingSurveyRepository.findByUser(user);
+        // 작성한 설문이 없을 때
+        if (meetingSurvey.isEmpty()) {
+            throw new RestApiException(SurveyErrorCode.NO_EXIST_SURVEY);
+        }
+        // 작성한 설문이 있을 때
+        else {
+            // 매칭 대기중일 떄
+            if (meetingSurvey.get().getMatchStatus() == MatchStatus.WAITING) {
+                throw new RestApiException(SurveyErrorCode.WAITING_FOR_MATCH);
+            }
+            // 매칭 성공했을 때
+            else if (meetingSurvey.get().getMatchStatus() == MatchStatus.MATCHED) {
+                // 내가 결제 안했을 때
+                
+                // 상대가 결제 안했을 때
+                
+                // 모두 결제 했을 때
+
+// 여자는 결제 안해도 된다는 요구사항
+            }
+        }
+        return null;
+    }
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/client/PaypleFeignConfig.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/client/PaypleFeignConfig.java
@@ -1,0 +1,13 @@
+package com.yapp.lonessum.domain.payment.client;
+
+import feign.form.FormEncoder;
+import org.springframework.context.annotation.Bean;
+
+public class PaypleFeignConfig {
+    class CustomConfig {
+        @Bean
+        FormEncoder formEncoder() {
+            return new FormEncoder();
+        }
+    }
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/client/PayplePartnerAuthClient.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/client/PayplePartnerAuthClient.java
@@ -1,0 +1,16 @@
+package com.yapp.lonessum.domain.payment.client;
+
+import com.yapp.lonessum.domain.payment.dto.PayplePartnerAuthRequest;
+import com.yapp.lonessum.domain.payment.dto.PayplePartnerAuthResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(
+        name = "payple-partner-auth",
+        url = "https://democpay.payple.kr/php/auth.php",
+        configuration = PaypleFeignConfig.class
+)
+public interface PayplePartnerAuthClient {
+    @PostMapping
+    PayplePartnerAuthResponse getPartnerAuth(PayplePartnerAuthRequest payplePartnerAuthRequest);
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/client/PayplePaymentCertClient.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/client/PayplePaymentCertClient.java
@@ -1,0 +1,16 @@
+package com.yapp.lonessum.domain.payment.client;
+
+import com.yapp.lonessum.domain.payment.dto.PayplePaymentCertRequest;
+import com.yapp.lonessum.domain.payment.dto.PayplePaymentCertResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(
+        name = "payple-payment-cert",
+        url = "https://democpay.payple.kr/php/PayCardConfirmAct.php?ACT_=PAYM",
+        configuration = PaypleFeignConfig.class
+)
+public interface PayplePaymentCertClient {
+    @PostMapping
+    PayplePaymentCertResponse certifyPayment(PayplePaymentCertRequest payplePaymentCertRequest);
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/controller/PaymentController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/controller/PaymentController.java
@@ -1,0 +1,57 @@
+package com.yapp.lonessum.domain.payment.controller;
+
+import com.yapp.lonessum.domain.payment.dto.*;
+import com.yapp.lonessum.domain.payment.service.PaymentService;
+import com.yapp.lonessum.domain.user.entity.UserEntity;
+import com.yapp.lonessum.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/payment")
+public class PaymentController {
+
+    private final UserService userService;
+    private final PaymentService paymentService;
+
+    /*
+    * 구매하기 버튼 -> 페이플 서버로 파트너 인증 요청 -> 파트너 인증 결과를 반환
+    * 클라이언트로 파트너 인증 결과와 추가 정보(주문id, 유저id 등) 반환
+    * */
+    @PostMapping
+    public ResponseEntity<PayplePartnerAuthResponse> getPartnerAuth() {
+        return ResponseEntity.ok(paymentService.getPartnerAuth());
+    }
+
+    /*
+     * 클라이언트에서 페이플 결제창 호출 후 결제 진행 -> 페이플 서버에서 외딴썸 서버로 결제 정보를 리다이렉트
+     * */
+    @PostMapping("/result")
+    public ResponseEntity<PayplePaymentResultResponse> receivePaymentResult(PayplePaymentResultResponse payplePaymentResultResponse) {
+        return ResponseEntity.ok(payplePaymentResultResponse);
+    }
+
+    /*
+    * 페이플 서버가 보낸 결제 정보를 가지고 결제 요청 재컨펌 (최종 승인)
+    * */
+    public ResponseEntity<PayplePaymentCertResponse> certifyPayment() {
+        return ResponseEntity.ok(paymentService.certifyPayment());
+    }
+
+    @PostMapping("/meeting")
+    public ResponseEntity payMeeting(@RequestHeader(value = "Authorization") String token) {
+        UserEntity user = userService.getUserFromToken(token);
+        return ResponseEntity.ok(paymentService.payMeeting(user.getMeetingSurvey()));
+    }
+
+    @PostMapping("/dating")
+    public ResponseEntity payDating(@RequestHeader(value = "Authorization") String token) {
+        UserEntity user = userService.getUserFromToken(token);
+        return ResponseEntity.ok(paymentService.payDating(user.getDatingSurvey()));
+    }
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/dto/PayplePartnerAuthRequest.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/dto/PayplePartnerAuthRequest.java
@@ -1,0 +1,9 @@
+package com.yapp.lonessum.domain.payment.dto;
+
+import lombok.Data;
+
+@Data
+public class PayplePartnerAuthRequest {
+    private String cst_id;
+    private String custKey;
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/dto/PayplePartnerAuthResponse.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/dto/PayplePartnerAuthResponse.java
@@ -1,0 +1,20 @@
+package com.yapp.lonessum.domain.payment.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class PayplePartnerAuthResponse {
+    private String server_name;
+    private String result;
+    private String result_msg;
+    private String cst_id;
+    private String custKey;
+    @JsonProperty("AuthKey")
+    private String AuthKey;
+    @JsonProperty("PCD_PAY_HOST")
+    private String PCD_PAY_HOST;
+    @JsonProperty("PCD_PAY_URL")
+    private String PCD_PAY_URL;
+    private String return_url;
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/dto/PayplePaymentCertRequest.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/dto/PayplePaymentCertRequest.java
@@ -1,0 +1,22 @@
+package com.yapp.lonessum.domain.payment.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class PayplePaymentCertRequest {
+    @JsonProperty("PCD_CST_ID")
+    private String PCD_CST_ID;
+
+    @JsonProperty("PCD_CUST_KEY")
+    private String PCD_CUST_KEY;
+
+    @JsonProperty("PCD_AUTH_KEY")
+    private String PCD_AUTH_KEY;
+
+    @JsonProperty("PCD_PAY_REQKEY")
+    private String PCD_PAY_REQKEY;
+
+    @JsonProperty("PCD_PAYER_ID")
+    private String PCD_PAYER_ID;
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/dto/PayplePaymentCertResponse.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/dto/PayplePaymentCertResponse.java
@@ -1,0 +1,91 @@
+package com.yapp.lonessum.domain.payment.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class PayplePaymentCertResponse {
+    @JsonProperty("PCD_PAY_RST")
+    private String PCD_PAY_RST;
+
+    @JsonProperty("PCD_PAY_CODE")
+    private String PCD_PAY_CODE;
+
+    @JsonProperty("PCD_PAY_MSG")
+    private String PCD_PAY_MSG;
+
+    @JsonProperty("PCD_PAY_TYPE")
+    private String PCD_PAY_TYPE;
+
+    @JsonProperty("PCD_PAY_REQKEY")
+    private String PCD_PAY_REQKEY;
+
+    @JsonProperty("PCD_PAY_OID")
+    private String PCD_PAY_OID;
+
+    @JsonProperty("PCD_PAYER_ID")
+    private String PCD_PAYER_ID;
+
+    @JsonProperty("PCD_PAYER_NO")
+    private String PCD_PAYER_NO;
+
+    @JsonProperty("PCD_PAYER_NAME")
+    private String PCD_PAYER_NAME;
+
+    @JsonProperty("PCD_PAYER_HP")
+    private String PCD_PAYER_HP;
+
+    @JsonProperty("PCD_PAYER_EMAIL")
+    private String PCD_PAYER_EMAIL;
+
+    @JsonProperty("PCD_PAY_GOODS")
+    private String PCD_PAY_GOODS;
+
+    @JsonProperty("PCD_PAY_TOTAL")
+    private String PCD_PAY_TOTAL;
+
+    @JsonProperty("PCD_PAY_TAXTOTAL")
+    private String PCD_PAY_TAXTOTAL;
+
+    @JsonProperty("PCD_PAY_ISTAX")
+    private String PCD_PAY_ISTAX;
+
+    @JsonProperty("PCD_PAY_TIME")
+    private String PCD_PAY_TIME;
+
+    @JsonProperty("PCD_PAYER_CARDNAME")
+    private String PCD_PAYER_CARDNAME;
+
+    @JsonProperty("PCD_PAYER_CARDNUM")
+    private String PCD_PAYER_CARDNUM;
+
+    @JsonProperty("PCD_PAYER_CARDTRADENUM")
+    private String PCD_PAYER_CARDTRADENUM;
+
+    @JsonProperty("PCD_PAYER_CARDAUTHNO")
+    private String PCD_PAYER_CARDAUTHNO;
+
+    @JsonProperty("PCD_PAYER_CARDRECEIPT")
+    private String PCD_PAYER_CARDRECEIPT;
+
+    @JsonProperty("PCD_SIMPLE_FLAG")
+    private String PCD_SIMPLE_FLAG;
+
+    @JsonProperty("PCD_PAY_BANK")
+    private String PCD_PAY_BANK;
+
+    @JsonProperty("PCD_PAY_BANKNAME")
+    private String PCD_PAY_BANKNAME;
+
+    @JsonProperty("PCD_PAY_BANKNUM")
+    private String PCD_PAY_BANKNUM;
+
+    @JsonProperty("PCD_TAXSAVE_MGTNUM")
+    private String PCD_TAXSAVE_MGTNUM;
+
+    @JsonProperty("PCD_TAXSAVE_FLAG")
+    private String PCD_TAXSAVE_FLAG;
+
+    @JsonProperty("PCD_TAXSAVE_RST")
+    private String PCD_TAXSAVE_RST;
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/dto/PayplePaymentResultResponse.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/dto/PayplePaymentResultResponse.java
@@ -1,0 +1,121 @@
+package com.yapp.lonessum.domain.payment.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class PayplePaymentResultResponse {
+    @JsonProperty("PCD_PAY_RST")
+    private String PCD_PAY_RST;
+
+    @JsonProperty("PCD_PAY_CODE")
+    private String PCD_PAY_CODE;
+
+    @JsonProperty("PCD_PAY_MSG")
+    private String PCD_PAY_MSG;
+
+    @JsonProperty("PCD_PAY_TYPE")
+    private String PCD_PAY_TYPE;
+
+    @JsonProperty("PCD_CARD_VER")
+    private String PCD_CARD_VER;
+
+    @JsonProperty("PCD_PAY_WORK")
+    private String PCD_PAY_WORK;
+
+    @JsonProperty("PCD_AUTH_KEY")
+    private String PCD_AUTH_KEY;
+
+    @JsonProperty("PCD_PAY_REQKEY")
+    private String PCD_PAY_REQKEY;
+
+    @JsonProperty("PCD_PAY_HOST")
+    private String PCD_PAY_HOST;
+
+    @JsonProperty("PCD_PAY_URL")
+    private String PCD_PAY_URL;
+
+    @JsonProperty("PCD_PAY_COFURL")
+    private String PCD_PAY_COFURL;
+
+    @JsonProperty("PCD_PAYER_ID")
+    private String PCD_PAYER_ID;
+
+    @JsonProperty("PCD_PAYER_NO")
+    private String PCD_PAYER_NO;
+
+    @JsonProperty("PCD_PAYER_NAME")
+    private String PCD_PAYER_NAME;
+
+    @JsonProperty("PCD_PAYER_HP")
+    private String PCD_PAYER_HP;
+
+    @JsonProperty("PCD_PAYER_EMAIL")
+    private String PCD_PAYER_EMAIL;
+
+    @JsonProperty("PCD_PAY_OID")
+    private String PCD_PAY_OID;
+
+    @JsonProperty("PCD_PAY_GOODS")
+    private String PCD_PAY_GOODS;
+
+    @JsonProperty("PCD_PAY_AMOUNT")
+    private String PCD_PAY_AMOUNT;
+
+    @JsonProperty("PCD_PAY_DISCOUNT")
+    private String PCD_PAY_DISCOUNT;
+
+    @JsonProperty("PCD_PAY_AMOUNT_REAL")
+    private String PCD_PAY_AMOUNT_REAL;
+
+    @JsonProperty("PCD_PAY_TOTAL")
+    private String PCD_PAY_TOTAL;
+
+    @JsonProperty("PCD_PAY_TAXTOTAL")
+    private String PCD_PAY_TAXTOTAL;
+
+    @JsonProperty("PCD_PAY_ISTAX")
+    private String PCD_PAY_ISTAX;
+
+    @JsonProperty("PCD_PAYER_CARDNAME")
+    private String PCD_PAYER_CARDNAME;
+
+    @JsonProperty("PCD_PAYER_CARDNUM")
+    private String PCD_PAYER_CARDNUM;
+
+    @JsonProperty("PCD_PAYER_CARDQUOTA")
+    private String PCD_PAYER_CARDQUOTA;
+
+    @JsonProperty("PCD_PAYER_CARDTRADENUM")
+    private String PCD_PAYER_CARDTRADENUM;
+
+    @JsonProperty("PCD_PAYER_CARDAUTHNO")
+    private String PCD_PAYER_CARDAUTHNO;
+
+    @JsonProperty("PCD_PAYER_CARDRECEIPT")
+    private String PCD_PAYER_CARDRECEIPT;
+
+    @JsonProperty("PCD_PAY_TIME")
+    private String PCD_PAY_TIME;
+
+    @JsonProperty("PCD_SIMPLE_FLAG")
+    private String PCD_SIMPLE_FLAG;
+
+    @JsonProperty("PCD_RST_URL")
+    private String PCD_RST_URL;
+
+    @JsonProperty("PCD_PAY_BANKACCTYPE")
+    private String PCD_PAY_BANKACCTYPE;
+
+    @JsonProperty("PCD_PAY_BANK")
+    private String PCD_PAY_BANK;
+
+    @JsonProperty("PCD_PAY_BANKNAME")
+    private String PCD_PAY_BANKNAME;
+
+    @JsonProperty("PCD_PAY_BANKNUM")
+    private String PCD_PAY_BANKNUM;
+
+    @JsonProperty("PCD_TAXSAVE_MGTNUM")
+    private String PCD_TAXSAVE_MGTNUM;
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/entity/MatchType.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/entity/MatchType.java
@@ -1,0 +1,5 @@
+package com.yapp.lonessum.domain.payment.entity;
+
+public enum MatchType {
+    MEETING, DATING
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/entity/Payment.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/entity/Payment.java
@@ -1,0 +1,23 @@
+package com.yapp.lonessum.domain.payment.entity;
+
+import com.yapp.lonessum.domain.dating.entity.DatingSurveyEntity;
+import com.yapp.lonessum.domain.meeting.entity.MeetingSurveyEntity;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+public class Payment {
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private MatchType matchType;
+
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "payment")
+    private MeetingSurveyEntity meetingSurvey;
+
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "payment")
+    private DatingSurveyEntity datingSurvey;
+
+    private LocalDateTime paidAt;
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/repository/PaymentRepository.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.yapp.lonessum.domain.payment.repository;
+
+import com.yapp.lonessum.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/service/PaymentService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/service/PaymentService.java
@@ -1,0 +1,40 @@
+package com.yapp.lonessum.domain.payment.service;
+
+import com.yapp.lonessum.domain.dating.entity.DatingSurveyEntity;
+import com.yapp.lonessum.domain.meeting.entity.MeetingSurveyEntity;
+import com.yapp.lonessum.domain.payment.client.PayplePartnerAuthClient;
+import com.yapp.lonessum.domain.payment.client.PayplePaymentCertClient;
+import com.yapp.lonessum.domain.payment.dto.PayplePartnerAuthRequest;
+import com.yapp.lonessum.domain.payment.dto.PayplePartnerAuthResponse;
+import com.yapp.lonessum.domain.payment.dto.PayplePaymentCertRequest;
+import com.yapp.lonessum.domain.payment.dto.PayplePaymentCertResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PayplePartnerAuthClient payplePartnerAuthClient;
+    private final PayplePaymentCertClient payplePaymentCertClient;
+
+    public PayplePartnerAuthResponse getPartnerAuth() {
+        PayplePartnerAuthRequest payplePartnerAuthRequest = new PayplePartnerAuthRequest();
+        payplePartnerAuthRequest.setCst_id("test");
+        payplePartnerAuthRequest.setCustKey("abcd1234567890");
+        return payplePartnerAuthClient.getPartnerAuth(payplePartnerAuthRequest);
+    }
+
+    public PayplePaymentCertResponse certifyPayment() {
+        PayplePaymentCertRequest payplePaymentCertRequest = new PayplePaymentCertRequest();
+        return payplePaymentCertClient.certifyPayment(payplePaymentCertRequest);
+    }
+
+    public Object payMeeting(MeetingSurveyEntity meetingSurvey) {
+        return null;
+    }
+
+    public Object payDating(DatingSurveyEntity datingSurvey) {
+        return null;
+    }
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/EmailService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/EmailService.java
@@ -48,20 +48,34 @@ public class EmailService {
         user.issueEmailToken(emailToken);
 
         //이메일 전송
-        sendEmail(email, emailToken.getAuthCode());
+        sendAuthCode(email, emailToken.getAuthCode());
 
         return emailToken.getExpireDate();
     }
 
     @Async
     @Transactional
-    public void sendEmail(String email, String authCode) {
+    public void sendAuthCode(String email, String authCode) {
         //이메일 메시지 생성
         SimpleMailMessage message = new SimpleMailMessage();
         message.setFrom(SERVICE_EMAIL);
         message.setTo(email);
         message.setSubject("외딴썸 이메일 인증코드입니다.");
         message.setText("다음 인증코드를 입력해주세요.\n"+authCode);
+
+        javaMailSender.send(message);
+    }
+
+    @Async
+    @Transactional
+    public void sendMatchResult(String email) {
+        //이메일 메시지 생성
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(SERVICE_EMAIL);
+        message.setTo(email);
+        message.setSubject("[외딴썸] 매칭이 성사되었습니다.");
+        message.setText("지금 매칭 결과를 확인해보세요!.\n");
+        message.setText("https://www.lonessum.com\n");
 
         javaMailSender.send(message);
     }

--- a/lonessum/src/main/java/com/yapp/lonessum/exception/errorcode/SurveyErrorCode.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/exception/errorcode/SurveyErrorCode.java
@@ -10,6 +10,9 @@ public enum SurveyErrorCode implements ErrorCode {
 
     NO_EXIST_SURVEY(HttpStatus.BAD_REQUEST, "작성한 설문이 없습니다."),
     ZERO_SURVEY(HttpStatus.BAD_REQUEST, "대기 중인 설문이 없습니다."),
+    WAITING_FOR_MATCH(HttpStatus.ACCEPTED, "매칭 대기중입니다."),
+    MATCH_SUCCESS(HttpStatus.ACCEPTED, "매칭이 성사되었습니다."),
+    WAITING_FOR_PAY(HttpStatus.ACCEPTED, "상대방이 결제할 때까지 대기중입니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
### 결제 ERD
- 세부 필드는 추가예정
- 설문 테이블과 1대1 연관관계

### 페이플 결제 플로우

> [https://developer.payple.kr/integration/simple-payment](url)

- 클라이언트가 구매 요청
- 외딴썸 서버가 페이플 서버로 파트너 인증 요청 -> 인증 결과 외딴썸 서버로 반환
- 외딴썸 서버가 인증 결과와 주문 정보를 클라이언트에게 전달
- 클라이언트가 외딴썸 서버로부터 받은 정보를 이용해 페이플 결제창 호출 및 결제 수행, redirect_url을 외딴썸 서버로 설정
- 페이플 서버가 redirect한 주문 결과를 외딴썸 서버가 받음
- 외딴썸 서버가 페이플 서버로 결제요청 재컨펌(최종 승인)
- 페이플 서버가 최종 승인 결과 외딴썸 서버로 반환
- 외딴썸 서버가 클라이언트로 결제 완료 신호 전송

### 구현 사항
- OpenFeign으로 페이플 서버로의 API 요청 작성
- 파트너 인증 요청 test : 완료
- 주문 결제 API test : 미완료

