### PR TITLE
[feat] : 테스트용 회원가입,로그인 작성, jwt 인증 구현

### DIFF
--- a/lonessum/pom.xml
+++ b/lonessum/pom.xml
@@ -63,6 +63,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- JWT -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.9.1</version>
+		</dependency>
+
 		<!-- springfox-swagger-ui -->
 		<dependency>
 			<groupId>io.springfox</groupId>

--- a/lonessum/src/main/java/com/yapp/lonessum/config/WebMvcConfig.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/config/WebMvcConfig.java
@@ -1,0 +1,29 @@
+package com.yapp.lonessum.config;
+
+import com.yapp.lonessum.config.jwt.JwtInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final JwtInterceptor jwtInterceptor;
+
+    private static final String[] EXCLUDE_PATHS = {
+            "/join",
+            "/login",
+            "/error",
+            "/swagger-ui",
+            "/h2-console"
+    };
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(jwtInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns(EXCLUDE_PATHS);
+    }
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/config/WebMvcConfig.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/config/WebMvcConfig.java
@@ -17,7 +17,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
             "/login",
             "/error",
             "/swagger-ui",
-            "/h2-console"
+            "/h2-console",
+            "/health"
     };
 
     @Override

--- a/lonessum/src/main/java/com/yapp/lonessum/config/jwt/JwtInterceptor.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/config/jwt/JwtInterceptor.java
@@ -1,0 +1,30 @@
+package com.yapp.lonessum.config.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+@RequiredArgsConstructor
+public class JwtInterceptor implements HandlerInterceptor {
+
+    private final JwtService jwtService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String url = request.getRequestURI();
+        if (url.contains("swagger") || url.contains("api-docs") || url.contains("webjars")) {
+            return true;
+        }
+        System.out.println("url = " + url);
+        String token = request.getHeader("Authorization");
+        if (token != null && token.length() > 0) {
+            return jwtService.isValid(token);
+        } else {
+            throw new RuntimeException("유효한 인증 토큰이 존재하지 않습니다.");
+        }
+    }
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/config/jwt/JwtService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/config/jwt/JwtService.java
@@ -1,0 +1,82 @@
+package com.yapp.lonessum.config.jwt;
+
+import com.yapp.lonessum.domain.user.entity.UserEntity;
+import com.yapp.lonessum.domain.user.repository.UserRepository;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtService {
+
+    private String secretKey = "lonessum";
+    private long accessTokenValidTime = 1000L * 60 * 60;
+    private long refreshTokenValidTime = 1000L * 60 * 60 * 24;
+
+    private final UserRepository userRepository;
+
+    public String createAccessToken(Long userId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setIssuedAt(now) // 토큰 발급시간
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenValidTime)) // 토큰 유효시간
+                .claim("userId", userId) // 토큰에 담을 데이터
+                .signWith(SignatureAlgorithm.HS256, secretKey.getBytes()) // secretKey를 사용하여 해싱 암호화 알고리즘 처리
+                .compact(); // 직렬화, 문자열로 변경
+    }
+
+    public String createRefreshToken() {
+        Date now = new Date();
+        return Jwts.builder()
+                .setIssuedAt(now) // 토큰 발급시간
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenValidTime)) // 토큰 유효시간
+                .signWith(SignatureAlgorithm.HS256, secretKey.getBytes()) // secretKey를 사용하여 해싱 암호화 알고리즘 처리
+                .compact(); // 직렬화, 문자열로 변경
+    }
+
+    public boolean isValid(String token) {
+        try {
+            Jwts.parser().setSigningKey(secretKey.getBytes()).parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            throw new RuntimeException("토큰이 유효하지 않습니다.");
+        }
+    }
+
+    public boolean isValidExceptExp(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey.getBytes()).parseClaimsJws(token);
+            return claims.getBody().getExpiration().before(new Date());
+        } catch (ExpiredJwtException e) {
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Long getTokenInfo() {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        String jwt = request.getHeader("Authorization");
+        Jws<Claims> claims = null;
+        try {
+            claims = Jwts.parser().setSigningKey(secretKey.getBytes()).parseClaimsJws(jwt); // secretKey를 사용하여 복호화
+        } catch (Exception e) {
+            throw new RuntimeException("토큰 정보를 불러올 수 없습니다.");
+        }
+        Object userId = claims.getBody().get("userId");
+        return Long.valueOf(userId.toString());
+    }
+
+    public UserEntity getUserFromJwt() {
+        Long userId = this.getTokenInfo();
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 유저입니다."));
+        return user;
+    }
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/dating/controller/DatingSurveyController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/dating/controller/DatingSurveyController.java
@@ -1,5 +1,6 @@
 package com.yapp.lonessum.domain.dating.controller;
 
+import com.yapp.lonessum.config.jwt.JwtService;
 import com.yapp.lonessum.domain.dating.dto.DatingSurveyDto;
 import com.yapp.lonessum.domain.dating.service.DatingSurveyService;
 import com.yapp.lonessum.domain.user.entity.UserEntity;
@@ -15,32 +16,37 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/dating/survey")
 public class DatingSurveyController {
 
+    private final JwtService jwtService;
     private final UserService userService;
     private final DatingSurveyService datingSurveyService;
 
     @PostMapping
     public ResponseEntity<Long> createSurvey(@RequestHeader(value = "Authorization") String token,
                                              @RequestBody DatingSurveyDto datingSurveyDto) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(datingSurveyService.createSurvey(user, datingSurveyDto));
     }
 
     @PostMapping("/rematch")
     public ResponseEntity<Long> rematchSurvey(@RequestHeader(value = "Authorization") String token) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(datingSurveyService.rematchSurvey(user));
     }
 
     @GetMapping
     public ResponseEntity<DatingSurveyDto> readSurvey(@RequestHeader(value = "Authorization") String token) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(datingSurveyService.readSurvey(user));
     }
 
     @PutMapping
     public ResponseEntity<Long> updateSurvey(@RequestHeader(value = "Authorization") String token,
                                              @RequestBody DatingSurveyDto datingSurveyDto) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(datingSurveyService.updateSurvey(user, datingSurveyDto));
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/controller/MeetingMatchingController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/controller/MeetingMatchingController.java
@@ -1,5 +1,6 @@
 package com.yapp.lonessum.domain.meeting.controller;
 
+import com.yapp.lonessum.config.jwt.JwtService;
 import com.yapp.lonessum.domain.meeting.service.MeetingMatchingService;
 import com.yapp.lonessum.domain.user.entity.UserEntity;
 import com.yapp.lonessum.domain.user.service.UserService;
@@ -15,12 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/meeting/matching")
 public class MeetingMatchingController {
 
+    private final JwtService jwtService;
     private final UserService userService;
     private final MeetingMatchingService meetingmatchingService;
 
     @GetMapping
     public ResponseEntity getMatchResult(@RequestHeader(value = "Authorization") String token) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(meetingmatchingService.getMatchResult(user));
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/controller/MeetingSurveyController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/controller/MeetingSurveyController.java
@@ -1,5 +1,6 @@
 package com.yapp.lonessum.domain.meeting.controller;
 
+import com.yapp.lonessum.config.jwt.JwtService;
 import com.yapp.lonessum.domain.meeting.dto.MeetingSurveyDto;
 import com.yapp.lonessum.domain.meeting.service.MeetingSurveyService;
 import com.yapp.lonessum.domain.user.entity.UserEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/meeting/survey")
 public class MeetingSurveyController {
 
+    private final JwtService jwtService;
     private final UserService userService;
     private final MeetingSurveyService meetingSurveyService;
 
@@ -26,7 +28,8 @@ public class MeetingSurveyController {
     @PostMapping
     public ResponseEntity<Long> createSurvey(@RequestHeader(value = "Authorization") String token,
                                              @RequestBody MeetingSurveyDto meetingSurveyDto) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(meetingSurveyService.createSurvey(user, meetingSurveyDto));
     }
 
@@ -35,26 +38,30 @@ public class MeetingSurveyController {
      * */
     @PostMapping("/rematch")
     public ResponseEntity<Long> rematchSurvey(@RequestHeader(value = "Authorization") String token) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(meetingSurveyService.rematchSurvey(user));
     }
 
     @GetMapping
     public ResponseEntity<MeetingSurveyDto> readSurvey(@RequestHeader(value = "Authorization") String token) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(meetingSurveyService.readSurvey(user));
     }
 
     @PutMapping
     public ResponseEntity<Long> updateSurvey(@RequestHeader(value = "Authorization") String token,
                                              @RequestBody MeetingSurveyDto meetingSurveyDto) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(meetingSurveyService.updateSurvey(user, meetingSurveyDto));
     }
 
     @DeleteMapping
     public ResponseEntity<Long> deleteSurvey(@RequestHeader(value = "Authorization") String token) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(meetingSurveyService.deleteSurvey(user));
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/payment/controller/PaymentController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/payment/controller/PaymentController.java
@@ -1,5 +1,6 @@
 package com.yapp.lonessum.domain.payment.controller;
 
+import com.yapp.lonessum.config.jwt.JwtService;
 import com.yapp.lonessum.domain.payment.dto.*;
 import com.yapp.lonessum.domain.payment.service.PaymentService;
 import com.yapp.lonessum.domain.user.entity.UserEntity;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/payment")
 public class PaymentController {
 
+    private final JwtService jwtService;
     private final UserService userService;
     private final PaymentService paymentService;
 
@@ -45,13 +47,15 @@ public class PaymentController {
 
     @PostMapping("/meeting")
     public ResponseEntity payMeeting(@RequestHeader(value = "Authorization") String token) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(paymentService.payMeeting(user.getMeetingSurvey()));
     }
 
     @PostMapping("/dating")
     public ResponseEntity payDating(@RequestHeader(value = "Authorization") String token) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(paymentService.payDating(user.getDatingSurvey()));
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/EmailController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/EmailController.java
@@ -1,6 +1,8 @@
 package com.yapp.lonessum.domain.user.controller;
 
+import com.yapp.lonessum.config.jwt.JwtService;
 import com.yapp.lonessum.domain.user.dto.AuthCodeRequest;
+import com.yapp.lonessum.domain.user.dto.EmailRequest;
 import com.yapp.lonessum.domain.user.entity.UserEntity;
 import com.yapp.lonessum.domain.user.service.EmailService;
 import com.yapp.lonessum.domain.user.service.UserService;
@@ -19,17 +21,21 @@ public class EmailController {
 
     private final EmailService emailService;
     private final UserService userService;
+    private final JwtService jwtService;
 
     @PostMapping
-    public ResponseEntity<LocalDateTime> updateAndSendEmail(@RequestHeader(value = "Authorization") String token, @RequestBody String email) {
-        UserEntity user = userService.getUserFromToken(token);
-        return ResponseEntity.ok(emailService.updateAndSendEmail(user, email));
+    public ResponseEntity<LocalDateTime> updateAndSendEmail(@RequestHeader(value = "Authorization") String token, @RequestBody EmailRequest emailRequest) {
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
+        System.out.println("user.getUserName() = " + user.getUserName());
+        return ResponseEntity.ok(emailService.updateAndSendEmail(user, emailRequest.getEmail()));
     }
 
     @PutMapping
     public ResponseEntity<Boolean> authenticateWithEmail(@RequestHeader(value = "Authorization") String token,
                                                   @RequestBody AuthCodeRequest authCodeRequest) {
-        UserEntity user = userService.getUserFromToken(token);
+//        UserEntity user = userService.getUserFromToken(token);
+        UserEntity user = jwtService.getUserFromJwt();
         return ResponseEntity.ok(emailService.authenticateWithEmail(user, authCodeRequest.getAuthCode()));
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/EmailController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/EmailController.java
@@ -27,7 +27,6 @@ public class EmailController {
     public ResponseEntity<LocalDateTime> updateAndSendEmail(@RequestHeader(value = "Authorization") String token, @RequestBody EmailRequest emailRequest) {
 //        UserEntity user = userService.getUserFromToken(token);
         UserEntity user = jwtService.getUserFromJwt();
-        System.out.println("user.getUserName() = " + user.getUserName());
         return ResponseEntity.ok(emailService.updateAndSendEmail(user, emailRequest.getEmail()));
     }
 

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/OAuthController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/OAuthController.java
@@ -4,6 +4,7 @@ import com.yapp.lonessum.domain.user.client.KakaoApiClient;
 import com.yapp.lonessum.domain.user.client.KakaoAuthClient;
 import com.yapp.lonessum.domain.user.dto.KakaoTokenRequest;
 import com.yapp.lonessum.domain.user.dto.KakaoTokenResponse;
+import com.yapp.lonessum.domain.user.dto.KakaoUserResponse;
 import com.yapp.lonessum.domain.user.service.UserService;
 import com.yapp.lonessum.exception.errorcode.UserErrorCode;
 import com.yapp.lonessum.exception.exception.RestApiException;

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/UserController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/UserController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.*;
 
 @CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
-@RequestMapping("/user")
 @RequiredArgsConstructor
 public class UserController {
 
@@ -25,7 +24,7 @@ public class UserController {
         return ResponseEntity.ok(userService.testJoin(joinRequest));
     }
 
-    @GetMapping("/login")
+    @PostMapping("/login")
     public ResponseEntity<LoginResponse> testLogin(@RequestBody LoginRequest loginRequest) {
         return ResponseEntity.ok(userService.testLogin(loginRequest));
     }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/UserController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/UserController.java
@@ -1,8 +1,13 @@
 package com.yapp.lonessum.domain.user.controller;
 
 import com.yapp.lonessum.domain.user.client.KakaoApiClient;
+import com.yapp.lonessum.domain.user.dto.JoinRequest;
 import com.yapp.lonessum.domain.user.dto.KakaoTokenInfoResponse;
+import com.yapp.lonessum.domain.user.dto.LoginRequest;
+import com.yapp.lonessum.domain.user.dto.LoginResponse;
+import com.yapp.lonessum.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -13,6 +18,17 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final KakaoApiClient kakaoApiClient;
+    private final UserService userService;
+
+    @PostMapping("/join")
+    public ResponseEntity<Long> testJoin(@RequestBody JoinRequest joinRequest) {
+        return ResponseEntity.ok(userService.testJoin(joinRequest));
+    }
+
+    @GetMapping("/login")
+    public ResponseEntity<LoginResponse> testLogin(@RequestBody LoginRequest loginRequest) {
+        return ResponseEntity.ok(userService.testLogin(loginRequest));
+    }
 
     //TODO : 이후에 제거
     //token 바탕 사용자 id 얻어오는 사용 예시

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/EmailRequest.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/EmailRequest.java
@@ -1,0 +1,8 @@
+package com.yapp.lonessum.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class EmailRequest {
+    private String email;
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/JoinRequest.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/JoinRequest.java
@@ -1,0 +1,9 @@
+package com.yapp.lonessum.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class JoinRequest {
+    private String userName;
+    private String password;
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/LoginRequest.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.yapp.lonessum.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+    private String userName;
+    private String password;
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/LoginResponse.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/LoginResponse.java
@@ -1,8 +1,10 @@
 package com.yapp.lonessum.domain.user.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class LoginResponse {
     private String accessToken;
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/LoginResponse.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/dto/LoginResponse.java
@@ -1,0 +1,8 @@
+package com.yapp.lonessum.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginResponse {
+    private String accessToken;
+}

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/entity/UserEntity.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/entity/UserEntity.java
@@ -19,6 +19,10 @@ public class UserEntity {
     @Id @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    private String userName;
+
+    private String password;
+
     private Long kakaoServerId;
   
     @ManyToOne(fetch = FetchType.LAZY)

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/repository/UserRepository.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/repository/UserRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByKakaoServerId(Long kakaoServerId);
+    Optional<UserEntity> findByUserName(String userName);
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.yapp.lonessum.domain.user.service;
 
+import com.yapp.lonessum.config.jwt.JwtService;
 import com.yapp.lonessum.domain.user.client.KakaoApiClient;
 import com.yapp.lonessum.domain.user.dto.*;
 import com.yapp.lonessum.domain.user.entity.UserEntity;
@@ -17,6 +18,7 @@ import java.util.Optional;
 public class UserService {
 
     private final KakaoApiClient kakaoApiClient;
+    private final JwtService jwtService;
     private final UserRepository userRepository;
 
     @Transactional
@@ -55,6 +57,13 @@ public class UserService {
 
     @Transactional
     public LoginResponse testLogin(LoginRequest loginRequest) {
-        return null;
+        UserEntity userEntity = userRepository.findByUserName(loginRequest.getUserName()).orElseThrow(() -> new RestApiException(UserErrorCode.INACTIVE_USER));
+        if (userEntity.getPassword().equals(loginRequest.getPassword())) {
+            String accessToken = jwtService.createAccessToken(userEntity.getId());
+            return new LoginResponse(accessToken);
+        }
+        else {
+            throw new RestApiException(UserErrorCode.WRONG_PASSWORD);
+        }
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
@@ -1,9 +1,7 @@
 package com.yapp.lonessum.domain.user.service;
 
 import com.yapp.lonessum.domain.user.client.KakaoApiClient;
-import com.yapp.lonessum.domain.user.dto.KakaoTokenInfoResponse;
-import com.yapp.lonessum.domain.user.dto.KakaoTokenResponse;
-import com.yapp.lonessum.domain.user.dto.KakaoUserResponse;
+import com.yapp.lonessum.domain.user.dto.*;
 import com.yapp.lonessum.domain.user.entity.UserEntity;
 import com.yapp.lonessum.domain.user.repository.UserRepository;
 import com.yapp.lonessum.exception.errorcode.UserErrorCode;
@@ -45,5 +43,18 @@ public class UserService {
     public void checkAdult(String token, Boolean isAdult) {
         UserEntity user = getUserFromToken(token);
         user.changeIsAdult(isAdult);
+    }
+
+    @Transactional
+    public Long testJoin(JoinRequest joinRequest) {
+        return userRepository.save(UserEntity.builder()
+                .userName(joinRequest.getUserName())
+                .password(joinRequest.getPassword())
+                .build()).getId();
+    }
+
+    @Transactional
+    public LoginResponse testLogin(LoginRequest loginRequest) {
+        return null;
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/service/UserService.java
@@ -52,6 +52,8 @@ public class UserService {
         return userRepository.save(UserEntity.builder()
                 .userName(joinRequest.getUserName())
                 .password(joinRequest.getPassword())
+                .isAdult(true)
+                .isAuthenticated(true)
                 .build()).getId();
     }
 

--- a/lonessum/src/main/java/com/yapp/lonessum/exception/errorcode/UserErrorCode.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/exception/errorcode/UserErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ErrorCode {
 
     INACTIVE_USER(HttpStatus.FORBIDDEN, "존재하지 않는 유저입니다."),
+    WRONG_PASSWORD(HttpStatus.FORBIDDEN, "비밀번호가 틀렸습니다."),
     NEED_EMAIL_AUTH(HttpStatus.FORBIDDEN, "이메일 인증되지 않은 유저입니다."),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "잘못된 이메일 형식입니다."),
     UNSUPPORTED_EMAIL(HttpStatus.BAD_REQUEST, "지원하지 않는 대학입니다."),


### PR DESCRIPTION
### 테스트용 회원가입, 로그인
- 테스트용으로 동작하는 회원가입, 로그인 작성

### jwt 인증
- 인터셉터에서 jwt 인증 구현
- accessToken을 "Authorization" 헤더에 담아 인증
- 토큰에서 유저정보를 가져오는 로직 컨트롤러에 적용

close #40 
close #63
close #64 