### PR TITLE
[fix] : Jwt 토큰에 대한 CORS Preflight 에러 처리

### DIFF
--- a/lonessum/src/main/java/com/yapp/lonessum/config/WebMvcConfig.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/config/WebMvcConfig.java
@@ -3,6 +3,7 @@ package com.yapp.lonessum.config;
 import com.yapp.lonessum.config.jwt.JwtInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -27,5 +28,15 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addInterceptor(jwtInterceptor)
                 .addPathPatterns("/**")
                 .excludePathPatterns(EXCLUDE_PATHS);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("*")
+                .allowedHeaders("Authorization", "Access-Control-Allow-Origin", "Access-Control-Allow-Credentials", "Content-Type")
+                .exposedHeaders("Content-Disposition", "Authorization", "Access-Control-Allow-Origin", "Access-Control-Allow-Credentials")
+                .allowCredentials(false).maxAge(3600);
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/config/jwt/JwtInterceptor.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/config/jwt/JwtInterceptor.java
@@ -19,6 +19,9 @@ public class JwtInterceptor implements HandlerInterceptor {
         if (url.contains("swagger") || url.contains("api-docs") || url.contains("webjars")) {
             return true;
         }
+        if (request.getMethod().equals("OPTIONS")) {
+            return true;
+        }
         System.out.println("url = " + url);
         String token = request.getHeader("Authorization");
         if (token != null && token.length() > 0) {

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/dating/controller/DatingSurveyController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/dating/controller/DatingSurveyController.java
@@ -9,8 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-
-@CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/dating/survey")

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/controller/MeetingSurveyController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/controller/MeetingSurveyController.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/meeting/survey")

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/AbroadAreaController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/AbroadAreaController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.*;
 import java.io.IOException;
 import java.util.List;
 
-@CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
 @RequestMapping("/areas")
 @RequiredArgsConstructor

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/EmailController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/EmailController.java
@@ -12,8 +12,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
-
-@CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
 @RequestMapping("/email")
 @RequiredArgsConstructor

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/OAuthController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/OAuthController.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/oauth")

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/UniversityController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/UniversityController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.*;
 import java.io.IOException;
 import java.util.List;
 
-@CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
 @RequestMapping("/university")
 @RequiredArgsConstructor

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/UserController.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/user/controller/UserController.java
@@ -10,8 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-
-@CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
 @RequiredArgsConstructor
 public class UserController {


### PR DESCRIPTION
https://ahndding.tistory.com/17

- 일반적이지 않은 요청(헤더에 토큰과 같은 별도의 값이 추가된 경우) 브라우저가 서버에게 Preflight 요청을 보냄
- 이 Preflight 요청에 대해 에러가 발생
- Preflight 요청에 대해서는 예외처리하도록 구현(HTTP Method가 OPTIONS인 경우)