### PR TITLE
[feat] : 다음날까지 결제하지 않은 유저는 FAILED 상태로 변한다

### DIFF
--- a/lonessum/src/main/java/com/yapp/lonessum/domain/dating/scheduler/DatingMatchingScheduler.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/dating/scheduler/DatingMatchingScheduler.java
@@ -9,6 +9,7 @@ import com.yapp.lonessum.domain.dating.entity.DatingSurveyEntity;
 import com.yapp.lonessum.domain.dating.repository.DatingMatchingRepository;
 import com.yapp.lonessum.domain.dating.repository.DatingSurveyRepository;
 import com.yapp.lonessum.domain.email.service.EmailService;
+import com.yapp.lonessum.domain.meeting.entity.MeetingSurveyEntity;
 import com.yapp.lonessum.exception.errorcode.SurveyErrorCode;
 import com.yapp.lonessum.exception.exception.RestApiException;
 import com.yapp.lonessum.mapper.DatingSurveyMapper;
@@ -82,5 +83,16 @@ public class DatingMatchingScheduler {
                 datingSurvey.changeMatchStatus(MatchStatus.FAILED);
             }
         }));
+    }
+
+    // 결제 마감 시간까지 결제하지 않은 유저는 MatchStatus가 MATCHED -> FAILED로 변경
+    @Transactional
+    @Scheduled(cron = "00 00 22 * * ?")
+    public void matchedToFailed() {
+        List<DatingSurveyEntity> matchedSurveyList = datingSurveyRepository.findAllByMatchStatus(MatchStatus.MATCHED)
+                .orElseThrow(() -> new RestApiException(SurveyErrorCode.NO_MATCHED_SURVEY));
+        matchedSurveyList.forEach((matchedSurvey) -> {
+            matchedSurvey.changeMatchStatus(MatchStatus.FAILED);
+        });
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/dating/scheduler/DatingMatchingScheduler.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/dating/scheduler/DatingMatchingScheduler.java
@@ -92,7 +92,10 @@ public class DatingMatchingScheduler {
         List<DatingSurveyEntity> matchedSurveyList = datingSurveyRepository.findAllByMatchStatus(MatchStatus.MATCHED)
                 .orElseThrow(() -> new RestApiException(SurveyErrorCode.NO_MATCHED_SURVEY));
         matchedSurveyList.forEach((matchedSurvey) -> {
+            // 남자 설문
             matchedSurvey.changeMatchStatus(MatchStatus.FAILED);
+            // 그와 매칭된 여자 설문
+            matchedSurvey.getDatingMatching().getFemaleSurvey().changeMatchStatus(MatchStatus.FAILED);
         });
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/scheduler/MeetingMatchingScheduler.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/scheduler/MeetingMatchingScheduler.java
@@ -1,6 +1,7 @@
 package com.yapp.lonessum.domain.meeting.scheduler;
 
 import com.yapp.lonessum.common.algorithm.MatchingInfo;
+import com.yapp.lonessum.domain.constant.Gender;
 import com.yapp.lonessum.domain.constant.MatchStatus;
 import com.yapp.lonessum.domain.meeting.algorithm.MeetingMatchingAlgorithm;
 import com.yapp.lonessum.domain.meeting.dto.MeetingSurveyDto;
@@ -89,7 +90,10 @@ public class MeetingMatchingScheduler {
         List<MeetingSurveyEntity> matchedSurveyList = meetingSurveyRepository.findAllByMatchStatus(MatchStatus.MATCHED)
                 .orElseThrow(() -> new RestApiException(SurveyErrorCode.NO_MATCHED_SURVEY));
         matchedSurveyList.forEach((matchedSurvey) -> {
+            // 남자 설문
             matchedSurvey.changeMatchStatus(MatchStatus.FAILED);
+            // 그와 매칭된 여자 설문
+            matchedSurvey.getMeetingMatching().getFemaleSurvey().changeMatchStatus(MatchStatus.FAILED);
         });
     }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/scheduler/MeetingMatchingScheduler.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/domain/meeting/scheduler/MeetingMatchingScheduler.java
@@ -81,4 +81,15 @@ public class MeetingMatchingScheduler {
             }
         }));
     }
+
+    // 결제 마감 시간까지 결제하지 않은 유저는 MatchStatus가 MATCHED -> FAILED로 변경
+    @Transactional
+    @Scheduled(cron = "00 00 22 * * ?")
+    public void matchedToFailed() {
+        List<MeetingSurveyEntity> matchedSurveyList = meetingSurveyRepository.findAllByMatchStatus(MatchStatus.MATCHED)
+                .orElseThrow(() -> new RestApiException(SurveyErrorCode.NO_MATCHED_SURVEY));
+        matchedSurveyList.forEach((matchedSurvey) -> {
+            matchedSurvey.changeMatchStatus(MatchStatus.FAILED);
+        });
+    }
 }

--- a/lonessum/src/main/java/com/yapp/lonessum/exception/errorcode/SurveyErrorCode.java
+++ b/lonessum/src/main/java/com/yapp/lonessum/exception/errorcode/SurveyErrorCode.java
@@ -10,6 +10,7 @@ public enum SurveyErrorCode implements ErrorCode {
 
     NO_EXISTING_SURVEY(HttpStatus.BAD_REQUEST, "작성한 설문이 없습니다."),
     NO_WAITING_SURVEY(HttpStatus.BAD_REQUEST, "대기 중인 설문이 없습니다."),
+    NO_MATCHED_SURVEY(HttpStatus.BAD_REQUEST, "결제 미완료 설문이 없습니다."),
     WAITING_FOR_MATCH(HttpStatus.ACCEPTED, "매칭 대기중입니다."),
     MATCH_SUCCESS(HttpStatus.ACCEPTED, "매칭이 성사되었습니다."),
     MATCH_FAIL(HttpStatus.ACCEPTED, "매칭에 실패했습니다."),


### PR DESCRIPTION
결제하지 않은 유저들의 MatchStatus를 FAILED로 변경하기 위해 결제 마감시간인 매일 밤 10시에 스케줄링을 수행